### PR TITLE
Add Cobalt-B simulacra & matrix to db

### DIFF
--- a/src/db/matrices.json
+++ b/src/db/matrices.json
@@ -1,5 +1,13 @@
 [
   {
+    "matrixId": "cobalt-b-matrix",
+    "matrixImg": "https://toweroffantasy.info/static/images/matrices/cobalt-b.webp",
+    "name": "Cobalt-B",
+    "rarity": "SSR",
+    "two": "Restore 1 dodge every 4 dodges. Dodge attacks add burn to the target, dealing 13%/17%/21%/25% attack damage per second for 10 seconds.",
+    "four": "Increases damage by 13%/17%/21%/25% to targets with abnormal statuses"
+  },
+  {
     "matrixId": "claudia-matrix",
     "matrixImg": "https://toweroffantasy.info/static/images/matrices/claudia.webp",
     "name": "Claudia",

--- a/src/db/simulacra.json
+++ b/src/db/simulacra.json
@@ -1,5 +1,63 @@
 [
   {
+    "id": "cobalt-b",
+    "weaponId": "blazing-revolver",
+    "simulacraImg": "https://i.imgur.com/cimh8Ti.png",
+    "weaponImg": "https://i.imgur.com/ODDgHiX.png",
+    "name": "Cobalt-B",
+    "weapon": "Blazing Revolver",
+    "element": "flame",
+    "type": "dps",
+    "baseStats": ["attack", "health", "crit"],
+    "shatter": { "rank":"S", "value": 12.5 },
+    "charge": { "rank": "A", "value": 10 },
+    "materials": ["flame", "red", "black"],
+    "effect": [
+      {
+        "title": "Flame",
+        "description": "Fully charged weapons will set the target on fire for 8 seconds with the next attack, causing ongoing damage of 58.00% of ATK every second. Ignited targets receive 50% efficacy from healing."
+      },
+      {
+        "title": "Flame Resonance",
+        "description": "Increase flame attack by 15% and flame resistance by 25%. Activate by equipping two or more flame weapons. This set effect also works with weapons in the off-hand slot. This effect does not stack repeatedly."
+      }
+    ], 
+    "advancement": [
+      "Each round of attacks deals additional damage equal to 2% of the target's current HP (cannot exceed 180% of ATK).",
+      "Increase the current weapon's base ATK growth by 16%.",
+      "Heavy Bombardment branch skill and Close Quarters dodge attack inflict Ion Scorch on targets that are already burned, dealing flame damage equal to 40% of ATK every second for 10 seconds.",
+      "Increase the current weapon's base ATK growth by 32%.",
+      "The damage from Ion Scorch increases to 60% of ATK. Successful attacks with any weapon's dodge skill will refresh the duration of Ion Scorch.",
+      "Barrage inflicts burn for 15 seconds. Successful attacks with any weapon's dodge skills reduce the cooldown of Barrage by 4 seconds. This effect has a 1.5 second cooldown."
+    ],
+    "awakening": {
+      "1200": "After Cobalt-B uses her discharge skill, restores a random amount of weapons charge between 50 to 120 points.",
+      "4000": "After Cobalt-B uses her discharge skill, restores a random amount of weapons charge between 90 to 180 points."
+    },
+    "gifts": {
+      "15": ["dumbbells", "snackBox", "strangePlant"],
+      "30": ["necklace", "toolbox", "strangeFragment"],
+      "60": [
+        "tataCards",
+        "foxFigure",
+        "catFigure",
+        "bearFigure",
+        "tataFigure",
+        "present",
+        "psp",
+        "linyeFigure",
+        "pearl"
+      ],
+      "80": [
+        "kitchenware",
+        "goldCoin",
+        "seal"
+      ]
+    }
+
+  },
+
+  {
     "id": "claudia",
     "weaponId": "guren-blade",
     "simulacraImg": "https://i.imgur.com/IwT2ddq.png",

--- a/src/db/simulacra.json
+++ b/src/db/simulacra.json
@@ -5,6 +5,7 @@
     "simulacraImg": "https://i.imgur.com/cimh8Ti.png",
     "weaponImg": "https://i.imgur.com/ODDgHiX.png",
     "name": "Cobalt-B",
+    "rarity": "SSR",
     "weapon": "Blazing Revolver",
     "element": "flame",
     "type": "dps",
@@ -54,9 +55,7 @@
         "seal"
       ]
     }
-
   },
-
   {
     "id": "claudia",
     "weaponId": "guren-blade",


### PR DESCRIPTION
I added the simulacra and the cobalt-b matrices to the db. These statistics are those of the global version